### PR TITLE
Enable build on stable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,25 +1,25 @@
 [[package]]
 name = "bitflags"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "byteorder"
-version = "1.2.2"
+version = "1.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bytes"
-version = "0.4.6"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "0.1.2"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -27,7 +27,7 @@ name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -40,18 +40,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "fuel_line"
 version = "0.1.0"
 dependencies = [
- "bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuel_line_derive 0.1.0",
- "uuid 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "fuel_line_derive"
 version = "0.1.0"
 dependencies = [
- "proc-macro2 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.13.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -59,18 +59,18 @@ name = "iovec"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.40"
+version = "0.2.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "proc-macro2"
-version = "0.3.6"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -78,29 +78,29 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rand"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "syn"
-version = "0.13.1"
+version = "0.13.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -111,11 +111,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "uuid"
-version = "0.6.2"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -125,7 +125,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi"
-version = "0.3.4"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -143,21 +143,21 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
-"checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
-"checksum byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "73b5bdfe7ee3ad0b99c9801d58807a9dbc9e09196365b0203853b99889ab3c87"
-"checksum bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "1b7db437d718977f6dc9b2e3fd6fc343c02ac6b899b73fdd2179163447bd9ce9"
-"checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
+"checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
+"checksum byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d"
+"checksum bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "40ade3d27603c2cb345eb0912aec461a6dec7e06a4ae48589904e808335c7afa"
+"checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
-"checksum libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "6fd41f331ac7c5b8ac259b8bf82c75c0fb2e469bbf37d2becbba9a6a2221965b"
-"checksum proc-macro2 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "49b6a521dc81b643e9a51e0d1cf05df46d5a2f3c0280ea72bcb68276ba64a118"
-"checksum quote 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7b0ff51282f28dc1b53fd154298feaa2e77c5ea0dba68e1fd8b03b72fbe13d2a"
-"checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
-"checksum syn 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "91b52877572087400e83d24b9178488541e3d535259e04ff17a63df1e5ceff59"
+"checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
+"checksum proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1b06e2f335f48d24442b35a19df506a835fb3547bc3c06ef27340da9acf5cae7"
+"checksum quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9949cfe66888ffe1d53e6ec9d9f3b70714083854be20fd5e271b232a017401e8"
+"checksum rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8356f47b32624fef5b3301c1be97e5944ecdd595409cc5da11d05f211db6cfbd"
+"checksum syn 0.13.11 (registry+https://github.com/rust-lang/crates.io-index)" = "14f9bf6292f3a61d2c716723fdb789a41bbe104168e6f496dc6497e531ea1b9b"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-"checksum uuid 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4670e1e935f7edd193a413f802e2ee52274aed62a09ccaab1656515c9c53a66"
+"checksum uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e1436e58182935dcd9ce0add9ea0b558e8a87befe01c1a301e6020aeb0876363"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-"checksum winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04e3bd221fcbe8a271359c04f21a76db7d0c6028862d1bb5512d85e1e2eb5bb3"
+"checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/fuel_line/benches/bench.rs
+++ b/fuel_line/benches/bench.rs
@@ -1,4 +1,3 @@
-#![feature(proc_macro)]
 #![feature(test)]
 
 // For tests
@@ -17,7 +16,6 @@ pub trait Render {
 
 #[cfg(test)]
 mod tests {
-  #![feature(proc_macro)]
 
   use bytes::{BytesMut, BufMut};
   use test::Bencher;

--- a/fuel_line/benches/bench.rs
+++ b/fuel_line/benches/bench.rs
@@ -1,0 +1,65 @@
+#![feature(proc_macro)]
+#![feature(test)]
+
+// For tests
+#[allow(unused_imports)]
+extern crate bytes;
+#[allow(unused_imports)]
+#[macro_use] extern crate fuel_line;
+#[macro_use] extern crate fuel_line_derive;
+#[allow(unused_imports)]
+extern crate uuid;
+extern crate test;
+
+pub trait Render {
+  fn render(&self) -> String;
+}
+
+#[cfg(test)]
+mod tests {
+  #![feature(proc_macro)]
+
+  use bytes::{BytesMut, BufMut};
+  use test::Bencher;
+  use Render;
+  use uuid::Uuid;
+
+  #[bench]
+  fn bench_render_derive(bencher: &mut Bencher) {
+    #[derive(Render)]
+    #[TemplateName = "./fuel_line/test_data/bench_template.txt"]
+    struct BenchTemplate {
+      a: String,
+      b: String
+    }
+
+    let mut t = BenchTemplate {
+      a: "".to_owned(),
+      b: "Title".to_owned()
+    };
+
+    bencher.iter(|| {
+      let a = Uuid::new_v4().to_string();
+      t.a = a;
+
+      t.render()
+    });
+  }
+
+  #[bench]
+  fn bench_buffer_concat(bencher: &mut Bencher) {
+    let b = "Title";
+
+    bencher.iter(|| {
+      let a = Uuid::new_v4().to_string();
+
+      let mut url = String::with_capacity(1 + ": ".len() + a.len() + b.len());
+      url.push_str(b);
+      url.push_str(": ");
+      url.push_str(&a);
+      url.push_str("\n");
+      url
+    });
+  }
+}
+

--- a/fuel_line/benches/bench.rs
+++ b/fuel_line/benches/bench.rs
@@ -4,7 +4,6 @@
 #[allow(unused_imports)]
 extern crate bytes;
 #[allow(unused_imports)]
-#[macro_use] extern crate fuel_line;
 #[macro_use] extern crate fuel_line_derive;
 #[allow(unused_imports)]
 extern crate uuid;
@@ -17,7 +16,6 @@ pub trait Render {
 #[cfg(test)]
 mod tests {
 
-  use bytes::{BytesMut, BufMut};
   use test::Bencher;
   use Render;
   use uuid::Uuid;
@@ -60,4 +58,3 @@ mod tests {
     });
   }
 }
-

--- a/fuel_line/src/lib.rs
+++ b/fuel_line/src/lib.rs
@@ -1,14 +1,8 @@
-#![feature(proc_macro)]
-#![feature(test)]
-
 // For tests
 #[allow(unused_imports)]
 extern crate bytes;
 #[allow(unused_imports)]
 #[macro_use] extern crate fuel_line_derive;
-#[allow(unused_imports)]
-extern crate uuid;
-extern crate test;
 
 pub trait Render {
   fn render(&self) -> String;
@@ -62,12 +56,9 @@ macro_rules! templatify_buffer {
 
 #[cfg(test)]
 mod tests {
-  #![feature(proc_macro)]
 
-  use bytes::{BytesMut, BufMut};
-  use test::Bencher;
+  use bytes::BytesMut;
   use Render;
-  use uuid::Uuid;
 
   #[test]
   fn templatify_should_work() {
@@ -103,42 +94,5 @@ mod tests {
     assert!(t.render() == "<h1>b_value</h1>\n<p>a_value</p>\n");
   }
 
-  #[bench]
-  fn bench_render_derive(bencher: &mut Bencher) {
-    #[derive(Render)]
-    #[TemplateName = "./fuel_line/test_data/bench_template.txt"]
-    struct BenchTemplate {
-      a: String,
-      b: String
-    }
-
-    let mut t = BenchTemplate {
-      a: "".to_owned(),
-      b: "Title".to_owned()
-    };
-
-    bencher.iter(|| {
-      let a = Uuid::new_v4().to_string();
-      t.a = a;
-
-      t.render()
-    });
-  }
-
-  #[bench]
-  fn bench_buffer_concat(bencher: &mut Bencher) {
-    let b = "Title";
-
-    bencher.iter(|| {
-      let a = Uuid::new_v4().to_string();
-
-      let mut url = String::with_capacity(1 + ": ".len() + a.len() + b.len());
-      url.push_str(b);
-      url.push_str(": ");
-      url.push_str(&a);
-      url.push_str("\n");
-      url
-    });
-  }
 }
 

--- a/fuel_line/src/lib.rs
+++ b/fuel_line/src/lib.rs
@@ -57,7 +57,7 @@ macro_rules! templatify_buffer {
 #[cfg(test)]
 mod tests {
 
-  use bytes::BytesMut;
+  use bytes::{BytesMut, BufMut};
   use Render;
 
   #[test]
@@ -95,4 +95,3 @@ mod tests {
   }
 
 }
-

--- a/fuel_line_derive/src/lib.rs
+++ b/fuel_line_derive/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(proc_macro)]
-
 extern crate proc_macro;
 extern crate proc_macro2;
 extern crate syn;


### PR DESCRIPTION
Fixes #1 
Fixes trezm/thruster-cli#1

I have removed all uses of `feature(proc_macro)` since it is avaialble in stable since 1.29.
I have moved benchmarks to `fuel_line/benches/bench.rs` to enable build on stable. The benchmarks require nightly.

Feel free to contact me if you have any questions.